### PR TITLE
Implement linear websocket client

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,19 +101,21 @@ const wsConfig = {
   key: API_KEY,
   secret: PRIVATE_KEY,
 
-  // The following parameters are optional:
+  /*
+    The following parameters are optional:
+  */
 
-  // defaults to false == testnet. set to true for livenet.
+  // defaults to false == testnet. Set to true for livenet.
   // livenet: true
 
-  // override which URL to use for websocket connections
-  // wsUrl: 'wss://stream.bytick.com/realtime'
-
-  // how often to check (in ms) that WS connection is still alive
-  // pingInterval: 10000,
+  // defaults to fase == inverse. Set to true for linear (USDT) trading.
+  // linear: true
 
   // how long to wait (in ms) before deciding the connection should be terminated & reconnected
   // pongTimeout: 1000,
+
+  // how often to check (in ms) that WS connection is still alive
+  // pingInterval: 10000,
 
   // how long to wait before attempting to reconnect (in ms) after connection is closed
   // reconnectTimeout: 500,
@@ -123,45 +125,60 @@ const wsConfig = {
 
   // config for axios to pass to RestClient. E.g for proxy support
   // requestOptions: { }
+
+  // override which URL to use for websocket connections
+  // wsUrl: 'wss://stream.bytick.com/realtime'
 };
 
 const ws = new WebsocketClient(wsConfig);
 
+// subscribe to multiple topics at once
 ws.subscribe(['position', 'execution', 'trade']);
+
+// and/or subscribe to individual topics on demand
 ws.subscribe('kline.BTCUSD.1m');
 
-ws.on('open', () => {
-  console.log('connection open');
+// Listen to events coming from websockets. This is the primary data source
+ws.on('update', data => {
+  console.log('update', data);
 });
 
-ws.on('update', message => {
-  console.log('update', message);
+// Optional: Listen to websocket connection open event (automatic after subscribing to one or more topics)
+ws.on('open', ({ wsKey, event }) => {
+  console.log('connection open for websocket with ID: ' + wsKey);
 });
 
+// Optional: Listen to responses to websocket queries (e.g. the response after subscribing to a topic)
 ws.on('response', response => {
   console.log('response', response);
 });
 
+// Optional: Listen to connection close event. Unexpected connection closes are automatically reconnected.
 ws.on('close', () => {
   console.log('connection closed');
 });
 
+// Optional: Listen to raw error events.
+// Note: responses to invalid topics are currently only sent in the "response" event.
 ws.on('error', err => {
   console.error('ERR', err);
 });
 ```
-See inverse [websocket-client.ts](./src/websocket-client.ts) for further information.
+See [websocket-client.ts](./src/websocket-client.ts) for further information.
 
 ### Customise Logging
 Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired:
 
 ```js
-const { RestClient, WebsocketClient, DefaultLogger } = require('bybit-api');
+const { WebsocketClient, DefaultLogger } = require('bybit-api');
 
 // Disable all logging on the silly level
 DefaultLogger.silly = () => {};
 
-const ws = new WebsocketClient({key: 'xxx', secret: 'yyy'}, DefaultLogger);
+const ws = new WebsocketClient(
+  { key: 'xxx', secret: 'yyy' },
+  DefaultLogger
+);
 ```
 
 ## Contributions & Thanks

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,7 @@
 export type LogParams = null | any;
 
+export type Logger = typeof DefaultLogger;
+
 export const DefaultLogger = {
   silly: (...params: LogParams): void => {
     console.log(params);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,7 +1,5 @@
 export type LogParams = null | any;
 
-export type Logger = typeof DefaultLogger;
-
 export const DefaultLogger = {
   silly: (...params: LogParams): void => {
     console.log(params);

--- a/src/util/WsStore.ts
+++ b/src/util/WsStore.ts
@@ -1,6 +1,7 @@
 import { WsConnectionState } from '../websocket-client';
 import { DefaultLogger, Logger } from '../logger';
 
+import WebSocket from 'isomorphic-ws';
 
 type WsTopicList = Set<string>;
 type KeyedWsTopicLists = {

--- a/src/util/WsStore.ts
+++ b/src/util/WsStore.ts
@@ -1,0 +1,63 @@
+import { DefaultLogger, Logger } from '../logger';
+
+export enum WsConnectionState {
+  READY_STATE_INITIAL,
+  READY_STATE_CONNECTING,
+  READY_STATE_CONNECTED,
+  READY_STATE_CLOSING,
+  READY_STATE_RECONNECTING
+};
+
+export default class WsStore {
+  private connections: {
+    [key: string]: WebSocket
+  };
+  private connectionState: {
+    [key: string]: WsConnectionState
+  }
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.connections = {}
+    this.connectionState = {};
+    this.logger = logger || DefaultLogger;
+  }
+
+  getConnection(key: string) {
+    return this.connections[key];
+  }
+
+  setConnection(key: string, wsConnection: WebSocket) {
+    const existingConnection = this.getConnection(key);
+    if (existingConnection) {
+      this.logger.info('WsStore setConnection() overwriting existing connection: ', existingConnection);
+    }
+    this.connections[key] = wsConnection;
+  }
+
+  clearConnection(key: string) {
+    const existingConnection = this.getConnection(key);
+    if (existingConnection) {
+      delete this.connections[key];
+    }
+  }
+
+  getConnectionState(key: string) {
+    return this.connectionState[key];
+  }
+
+  setConnectionState(key: string, state: WsConnectionState) {
+    this.connectionState[key] = state;
+  }
+
+  isConnectionState(key: string, state: WsConnectionState) {
+    const a = this.getConnectionState(key) === state;
+    const b = this.getConnectionState(key) == state;
+    if (a != b) {
+      console.error('connection state doesnt match: ', { state, storedState: this.getConnectionState(key) });
+    } else {
+      console.log('isConnectionState matches');
+    }
+    return this.getConnectionState(key) === state;
+  }
+}

--- a/src/util/WsStore.ts
+++ b/src/util/WsStore.ts
@@ -1,12 +1,18 @@
 import { WsConnectionState } from '../websocket-client';
 import { DefaultLogger, Logger } from '../logger';
 
+
+type WsTopicList = Set<string>;
+type KeyedWsTopicLists = {
+  [key: string]: WsTopicList;
+};
+
 interface WsStoredState {
   ws?: WebSocket;
   connectionState?: WsConnectionState;
   activePingTimer?: NodeJS.Timeout | undefined;
   activePongTimer?: NodeJS.Timeout | undefined;
-  subscribedTopics: Set<string>;
+  subscribedTopics: WsTopicList;
 };
 
 export default class WsStore {
@@ -30,6 +36,10 @@ export default class WsStore {
     }
 
     return undefined;
+  }
+
+  getKeys(): string[] {
+    return Object.keys(this.wsState);
   }
 
   create(key: string): WsStoredState | undefined {
@@ -91,8 +101,16 @@ export default class WsStore {
 
   /* subscribed topics */
 
-  getTopics(key: string): Set<string> {
+  getTopics(key: string): WsTopicList {
     return this.get(key, true)!.subscribedTopics;
+  }
+
+  getTopicsByKey(): KeyedWsTopicLists {
+    const result = {};
+    for (const refKey in this.wsState) {
+      result[refKey] = this.getTopics(refKey);
+    }
+    return result;
   }
 
   addTopic(key: string, topic: string) {

--- a/src/util/WsStore.ts
+++ b/src/util/WsStore.ts
@@ -1,5 +1,5 @@
 import { WsConnectionState } from '../websocket-client';
-import { DefaultLogger, Logger } from '../logger';
+import { DefaultLogger } from '../logger';
 
 import WebSocket from 'isomorphic-ws';
 
@@ -20,9 +20,9 @@ export default class WsStore {
   private wsState: {
     [key: string]: WsStoredState;
   }
-  private logger: Logger;
+  private logger: typeof DefaultLogger;
 
-  constructor(logger: Logger) {
+  constructor(logger: typeof DefaultLogger) {
     this.logger = logger || DefaultLogger;
     this.wsState = {};
   }

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -57,7 +57,7 @@ export function getBaseRESTInverseUrl(useLivenet?: boolean, restInverseOptions?:
   }
   return baseUrlsInverse.testnet;
 }
-      
+
 export function isPublicEndpoint (endpoint: string): boolean {
   if (endpoint.startsWith('v2/public')) {
     return true;
@@ -66,4 +66,13 @@ export function isPublicEndpoint (endpoint: string): boolean {
     return true;
   }
   return false;
+}
+
+export function isWsPong(response: any) {
+  return (
+    response.request &&
+    response.request.op === 'ping' &&
+    response.ret_msg === 'pong' &&
+    response.success === true
+  );
 }

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -129,7 +129,6 @@ export class WebsocketClient extends EventEmitter {
     this.wsStore.getKeys().forEach(wsKey => {
       // if connected, send subscription request
       if (this.wsStore.isConnectionState(wsKey, READY_STATE_CONNECTED)) {
-        console.log(`${wsKey} is supposedly connected - sending request for topics`);
         return this.requestSubscribeTopics(wsKey, [...this.wsStore.getTopics(wsKey)]);
       }
 
@@ -332,7 +331,7 @@ export class WebsocketClient extends EventEmitter {
     try {
       this.logger.silly(`Sending upstream ws message: `, { ...loggerCategory, wsMessage, wsKey });
       if (!wsKey) {
-        console.error('ws with key: ', wsKey, ' not found');
+        throw new Error('Cannot send message due to no known websocket for this wsKey');
       }
       this.getWs(wsKey)?.send(wsMessage);
     } catch (e) {

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { InverseClient } from './inverse-client';
 import { LinearClient } from './linear-client';
-import { DefaultLogger, Logger } from './logger';
+import { DefaultLogger } from './logger';
 import { signMessage, serializeParams, isWsPong } from './util/requestUtils';
 
 import WebSocket from 'isomorphic-ws';
@@ -76,12 +76,12 @@ const getLinearWsKeyForTopic = (topic: string) => {
 }
 
 export class WebsocketClient extends EventEmitter {
-  private logger: Logger;
+  private logger: typeof DefaultLogger;
   private restClient: InverseClient | LinearClient;
   private options: WebsocketClientOptions;
   private wsStore: WsStore;
 
-  constructor(options: WSClientConfigurableOptions, logger?: Logger) {
+  constructor(options: WSClientConfigurableOptions, logger?: typeof DefaultLogger) {
     super();
 
     this.logger = logger || DefaultLogger;

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -276,7 +276,7 @@ export class WebsocketClient extends EventEmitter {
   private clearPongTimer(wsKey: string) {
     const wsState = this.wsStore.get(wsKey);
     if (wsState?.activePongTimer) {
-      clearInterval(wsState.activePongTimer);
+      clearTimeout(wsState.activePongTimer);
       wsState.activePongTimer = undefined;
     }
   }

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -169,9 +169,9 @@ export class WebsocketClient extends EventEmitter {
   /**
    * Request connection of all dependent websockets, instead of waiting for automatic connection by library
    */
-  public connectAll(): Promise<WebSocket> | Promise<WebSocket>[] | undefined {
+  public connectAll(): Promise<WebSocket>[] | undefined {
     if (this.isInverse()) {
-      return this.connect(wsKeyInverse);
+      return [this.connect(wsKeyInverse)];
     }
 
     if (this.options.linear === true) {


### PR DESCRIPTION
- Refactored websocket state into flexible wsStore. All websocket-specific state is now stored here.
- Existing inverse websocket functionality is unchanged.
- **Breaking change**: websocket connection on init
  - **Previous behaviour**: websocket is automatically connected when websocket-client() instance is made.
  - **New behaviour**: websocket is automatically connected when a topic is subscribed to.
  - If the previous behaviour is necessary, earlier connections can be forced using the websocketClient.connectAll() method.
